### PR TITLE
Replace window to globalThis

### DIFF
--- a/src/globalthis-polyfill.ts
+++ b/src/globalthis-polyfill.ts
@@ -1,0 +1,11 @@
+(function () {
+  if (typeof globalThis === "object") return;
+  // @ts-ignore
+  Object.prototype.__defineGetter__("__alloc__", function () {
+    return this;
+  });
+  // @ts-ignore
+  __alloc__.globalThis = __alloc__;
+  // @ts-ignore
+  delete Object.prototype.__alloc__;
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import './globalthis-polyfill'
 import Render from "./render";
 import { createPostMessageListener } from './observable'
 
@@ -28,7 +29,7 @@ export class Connect {
  };
 
  constructor(props) {
-  this.domain = window.location.origin;
+  this.domain = globalThis.location.origin;
   this.session = props.session;
   this.env = props.env;
   this.getOrigin = (env: string | void) => {
@@ -123,4 +124,4 @@ export class Connect {
 }
 }
 
-window.Connect = window.Connect || Connect;
+globalThis.Connect = globalThis.Connect || Connect;

--- a/src/observable.ts
+++ b/src/observable.ts
@@ -28,9 +28,8 @@ export function createPostMessageListener({
     notifyAll(hook);
   }
 
-    window.addEventListener("message", eventData);
-     
-   
+  globalThis.addEventListener("message", eventData);
+
   return {
     subscribe,
   }

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,5 +1,5 @@
 const Render = (session: string, domain: string) => {
-    const iframe = document.createElement('iframe');
+    const iframe = globalThis.document.createElement('iframe');
     iframe.setAttribute('src', `${session}&domain=${domain}&embedded=true`);
     iframe.setAttribute('id', 'connect-embedded-18100062243781');
     iframe.setAttribute('style', `
@@ -15,7 +15,7 @@ const Render = (session: string, domain: string) => {
         width: 100%;
         height: 100%;
     `);
-    document.body.appendChild(iframe);
+    globalThis.document.body.appendChild(iframe);
 };
 
 export default Render;


### PR DESCRIPTION
In many cases when we are using gatsby or webpack, we need to build the project with `hydrate` to generate html in output. This PR fix issue #11 

PS: I'm added polyfill